### PR TITLE
Break procedure into sub-procedures and add markup for accessibility

### DIFF
--- a/stories/topics/ref-aap-aws-add-extension-nodes.adoc
+++ b/stories/topics/ref-aap-aws-add-extension-nodes.adoc
@@ -2,36 +2,48 @@
 
 = Adding extension nodes to {PlatformNameShort} from {Market}
 
-By default, only the foundation stack is deployed with 2 {ControllerName} nodes and 1 {HubName} node. Execution nodes can be added to scale out {PlatformNameShort} from {Market}.
+By default, the foundation stack is deployed with two {ControllerName} nodes and one {HubName} node.
+You can add execution nodes to scale out {PlatformNameShort} from {Market}.
 Follow these steps to add execution nodes into your {PlatformNameShort} from {Market} environment:
 
-. Open the {ControllerName} Launch Configuration
-.. Navigate to the AWS CloudFormation UI and click the *Resources* tab. Ensure *Tree View* is selected in the top right corner.
-.. Expand *controller*, then *autoscale-group*, then *Launch Config*.
-.. Click the Launch Config Physical ID to open the launch configuration in a new tab.
-. Create the extension node launch configuration
-.. In the Launch configuration tab, ensure the {ControllerName} launch configuration is selected, then click *Copy to launch template*, then *Copy selected*.
-.. Replace the *New launch template name* with the name *extension-group-template* and ensure the checkbox for *Create an Auto Scaling group using the new template* is checked. Click Copy.
-.. For the Auto Scaling group name, enter 'extension-group'
-.. Under *Launch Template*, click 'Create a launch template version' to create a new verison of the launch template
-.. Under *Application and OS Images*, search for 'AAP-2.2.1-EXT_HVM-2022-10-27-19-13-28-x86_64-1-Marketplace-GP2', and click 'Select' next to the AMI which has this name.
-.. If prompted, confirm the changes
-.. (Optional) Modify the desired Instance type. Must be either m5.large, m5.xlarge, or m5.2xlarge. Default is m5.large.
-.. Scroll down to the *Storage* category. Drop down *Volume 1*. 
-... Ensure the *Size (GiB)* is set to 100
-... Ensure *Encrypted* is set to 'Encrypted'
-.. Click *Create template version*
-.. Navigate back to the previous tab with the *Choose launch template or configuration* header
-.. Click the refresh icon under *Version*, in the *Launch template* section
-.. Select the latest option, which we have just created, then click *Next*
-.. Under *Network*, ensure the correct VPC is selected
-... The correct VPC can be found quickly from the Cloudformation resources page by dropping down *Network*, then *VPC* in tree view.
-... Select the matching VPC ID
-.. Under *Availability Zones and subnets*, select all available options, then click *Next*
-.. At the *Configure advanced options* page, click *Next*
-.. Configure the *Group size* capacity as desired, then click *Next*
-.. At the *Add notifications* page, click *Next*
-.. At the *Add tags* page, click *Next*
-.. At the *Review* page, scroll to the bottom and click *Create Auto Scaling group*
+.Open the {ControllerName} Launch Configuration
+
+. Navigate to the AWS CloudFormation UI and click the *Resources* tab. Ensure *Tree View* is selected.
+. Click menu:controller[autoscale-group>Launch Config].
+. Click the Launch Config Physical ID to open the launch configuration in a new tab.
+
+.Create the extension node launch configuration
+
+. In the *Launch configuration* tab, ensure the {ControllerName} launch configuration is selected.
+Click *Copy to launch template*, then *Copy selected*.
+. Replace the *New launch template name* with *extension-group-template*.
+Ensure the checkbox for *Create an Auto Scaling group using the new template* is checked.
+Click btn:[Copy].
+. For the Auto Scaling group name, enter `extension-group`.
+. Under *Launch Template*, click btn[Create a launch template version] to create a new version of the launch template.
+. Under *Application and OS Images*, search for 'AAP-2.2.1-EXT_HVM-2022-10-27-19-13-28-x86_64-1-Marketplace-GP2', and click btn[Select] next to the AMI which has this name.
+. If prompted, confirm the changes.
+. (Optional) Modify the Instance type.
+Valid values are m5.large, m5.xlarge, or m5.2xlarge. The default is m5.large.
+. Scroll down to the *Storage* category.
+Expand *Volume 1*. 
+.. Set *Size (GiB)* to 100.
+.. Ensure *Encrypted* is set to `Encrypted`.
+. Click *Create template version*.
+
+.Create the auto scaling group
+
+. Navigate back to the *Choose launch template or configuration* tab.
+. In the *Launch template* section, click the *refresh* icon under *Version*.
+. Select the latest option, which we have just created, then click btn[Next].
+. Under *Network*, ensure the correct VPC is selected.
+.. To find the correct VPC, click menu:Network[VPC] to display the Cloudformation resources.
+.. Select the matching VPC ID.
+. Under *Availability Zones and subnets*, select all available options, then click btn[Next].
+. In the *Configure advanced options* page, click btn[Next].
+. Configure the *Group size* capacity, then click btn[Next].
+. In the *Add notifications* page, click btn[Next].
+. In the *Add tags* page, click btn[Next].
+. In the *Review* page, scroll to the bottom and click *Create Auto Scaling group*.
 . Wait for the Auto scaling group to create the nodes and for the related nodes to reach a _Running_ instance state.
-. The extension node EC2 instances should now be visible in the Automation Controller UI under Administration -> Instances.
+. To view the extension node EC2 instances in the {ControllerName} UI, click menu:Administration[Instances].


### PR DESCRIPTION
- Made modifications to comply with IBM style guide (for example, use "one" instead of "1") and Red Hat supplementary style guide (https://redhat-documentation.github.io/supplementary-style-guide/).
- Split procedure into separate blocks.
- Added UI elements for accessibility. See https://redhat-documentation.github.io/asciidoc-markup-conventions/. These don't render properly in Asciidoctor.